### PR TITLE
Take Wordpress timezone into account

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -43,11 +43,15 @@ function time_restricted_shortcode( $atts, $content ) {
 		$off = $hide;
 	}
 
-	if ( empty( $on ) || strtotime( $on ) < current_time( 'timestamp' ) ) { // If on time isn't set, or has already passed, show the content.
+	$now = current_datetime();
+
+	$time_on = new DateTimeImmutable( $on, wp_timezone() );
+	if ( empty( $on ) || $time_on < $now ) { // If on time isn't set, or has already passed, show the content.
 		$showit = 1;
 	}
 
-	if ( empty( $off ) || strtotime( $off ) > current_time( 'timestamp' ) ) {  // If off time isn't set, or is in the future, show the content.
+	$time_off = new DateTimeImmutable( $off, wp_timezone() );
+	if ( empty( $off ) || $time_off > $now ) {  // If off time isn't set, or is in the future, show the content.
 		$hideit = 0;
 	}
 


### PR DESCRIPTION
Use DateTimeImmutable objects to compare the 'time-restrict' shortcode's
on/off times, ensuring consistency in the time zones handling. Previous
use of strtotime() was causing UTC to be used as reference.

If not specified in the on/off string, timezone is defaulted to the one
defined in Wordpress.

Fixes #44